### PR TITLE
feat(http): add --host option for HTTP server and log host/port; docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,21 @@ uv pip install httpx fastmcp
 # The setup for apktool-mcp-server is done.
 ```
 
+### HTTP mode (optional)
+
+```bash
+# Default (binds to 127.0.0.1:8652)
+uv run apktool_mcp_server.py --http
+
+# Expose on all interfaces
+uv run apktool_mcp_server.py --http --host 0.0.0.0 --port 8652
+
+# Bind to a specific local IP
+uv run apktool_mcp_server.py --http --host 192.168.1.50 --port 8652
+```
+
+Note: Exposing on 0.0.0.0 makes the server reachable on your LAN. Ensure appropriate network controls.
+
 ## 2. Running on Local LLM Using Ollama and Zin MCP Client - Recommended
 
 <div align="center">

--- a/apktool_mcp_server.py
+++ b/apktool_mcp_server.py
@@ -33,6 +33,7 @@ logger.addHandler(console_handler)
 parser = argparse.ArgumentParser("APKTool MCP Server")
 parser.add_argument("--http", help="Serve MCP Server over HTTP stream.", action="store_true", default=False)
 parser.add_argument("--port", help="Specify the port number for --http to serve on. (default:8652)", default=8652, type=int)
+parser.add_argument("--host", help="Specify the host/interface to bind for --http (default:127.0.0.1). Use 0.0.0.0 to listen on all interfaces.", default="127.0.0.1", type=str)
 parser.add_argument("--workspace", help="Specify workspace directory for APK projects", default="apktool_mcp_server_workspace", type=str)
 parser.add_argument("--timeout", help="Default timeout for APKTool commands in seconds", default=300, type=int)
 args = parser.parse_args()
@@ -1663,6 +1664,7 @@ def main():
     print(f"  Default Timeout: {DEFAULT_TIMEOUT}s")
     print(f"  HTTP Mode: {'Enabled' if args.http else 'Disabled'}")
     if args.http:
+        print(f"  HTTP Host: {args.host}")
         print(f"  HTTP Port: {args.port}")
     print()
     
@@ -1720,8 +1722,8 @@ def main():
     print("Starting MCP server...")
     
     if args.http:
-        print(f"Server will be available at: http://127.0.0.1:{args.port}")
-        mcp.run(transport="streamable-http", port=args.port)
+        print(f"Server will be available at: http://{args.host}:{args.port}")
+        mcp.run(transport="streamable-http", host=args.host, port=args.port)
     else:
         print("Server running in stdio mode")
         mcp.run()


### PR DESCRIPTION
## Summary of Changes
- Add `--host` CLI flag (default `127.0.0.1`) for HTTP bind interface.
- Log HTTP host and port at startup; URL now shows `http://{host}:{port}`.
- Pass `host` into `mcp.run(transport="streamable-http", host=..., port=...)`.
- Update `README.md` with HTTP mode usage examples and a security note.

## Testing
- [ ] Ran all existing tests
- [ ] Added new tests
- [x] Manually tested features

## Checklist
- [x] My code follows the project’s coding style.
- [ ] I have added tests that prove my fix/feature works.
- [x] I have updated documentation where necessary.
- [x] My changes do not break existing functionality.
- [x] I have rebased on the latest `main` branch.

## Additional Notes
- Binding to `0.0.0.0` exposes the server on your LAN; ensure proper network controls.
- Backwards compatible: default host remains `127.0.0.1`; stdio behavior unchanged.
